### PR TITLE
fix: replace removed bilibili dynamic card endpoint

### DIFF
--- a/packages/core/src/model/fetchers/bilibili/bound.ts
+++ b/packages/core/src/model/fetchers/bilibili/bound.ts
@@ -81,7 +81,12 @@ export interface IBoundBilibiliFetcher {
   /** 获取B站动态详情 */
   fetchDynamicDetail: BoundMethodOverload<BilibiliDynamicOptions, BilibiliReturnTypeMap['dynamicDetail']>
 
-  /** 获取B站动态卡片信息 */
+  /**
+   * 获取B站动态卡片信息
+   * @deprecated v6.1.3 已废弃，B站官方已于 `2025-08-09` 删除原 `dynamic_svr` 接口。
+   * 调用将返回错误信息
+   * 计划于 v7.0.0 移除。
+   */
   fetchDynamicCard: BoundMethodOverload<BilibiliDynamicOptions, BilibiliReturnTypeMap['dynamicCard']>
 
   // ==================== 番剧相关 ====================
@@ -178,6 +183,7 @@ export function createBoundBilibiliFetcher (
 
     // 动态
     fetchDynamicDetail: (options) => fetchDynamicDetail(options, cookie, requestConfig),
+    /** @deprecated v6.1.3 已废弃，调用将返回错误信息 */
     fetchDynamicCard: (options) => fetchDynamicCard(options, cookie, requestConfig),
 
     // 番剧

--- a/packages/core/src/model/fetchers/bilibili/dynamic.ts
+++ b/packages/core/src/model/fetchers/bilibili/dynamic.ts
@@ -5,6 +5,7 @@
 
 import { RequestConfig } from 'amagi/server'
 import { BilibiliReturnTypeMap } from 'amagi/types/ReturnDataType/Bilibili'
+import { checkDeprecation } from 'amagi/utils/deprecation'
 import { Result } from 'amagi/validation'
 
 import type { BilibiliDynamicOptions, ConditionalReturnType, TypeMode } from '../types'
@@ -33,15 +34,20 @@ export async function fetchDynamicDetail<M extends TypeMode = 'loose'> (
 
 /**
  * 获取B站动态卡片信息
+ *
+ * @deprecated v6.1.3 已废弃，B站官方已于 `2025-08-09` 删除原 `dynamic_svr` 接口。
+ * 调用将返回错误信息
+ * 计划于 v7.0.0 移除。
+ *
  * @param options - 动态参数
  * @param options.dynamic_id - 动态 ID
  * @param cookie - B站 Cookie (可选)
  * @param requestConfig - 请求配置 (可选)
- * @returns 动态卡片数据
+ * @returns 动态卡片数据（已停用，返回错误信息）
  * @example
  * ```typescript
  * const result = await fetchDynamicCard({ dynamic_id: '123456789' }, cookie)
- * console.log(result.data.card) // 动态卡片
+ * // result.success === false，错误信息提示接口已停用
  * ```
  */
 export async function fetchDynamicCard<M extends TypeMode = 'loose'> (
@@ -49,5 +55,6 @@ export async function fetchDynamicCard<M extends TypeMode = 'loose'> (
   cookie?: string,
   requestConfig?: RequestConfig
 ): Promise<Result<ConditionalReturnType<BilibiliReturnTypeMap['dynamicCard'], M>>> {
+  checkDeprecation('fetchDynamicCard')
   return fetchBilibiliInternal('dynamicCard', options, { cookie, requestConfig })
 }

--- a/packages/core/src/model/fetchers/bilibili/internal.ts
+++ b/packages/core/src/model/fetchers/bilibili/internal.ts
@@ -32,15 +32,21 @@ export async function fetchBilibiliInternal<T extends keyof BilibiliDataOptionsM
     const duration = Date.now() - startTime
 
     if (rawData.code !== 0) {
+      const errorMessage = rawData.message || 'B站数据获取失败'
       emitApiError({
         platform: 'bilibili',
         methodType,
         errorCode: rawData.code,
-        errorMessage: 'B站数据获取失败',
+        errorMessage,
         url: undefined,
         duration
       })
-      return createErrorResponse(rawData.amagiError, 'B站数据获取失败', rawData.code, rawData.data)
+      const amagiError = rawData.amagiError ?? {
+        errorDescription: errorMessage,
+        requestType: methodType,
+        requestUrl: undefined
+      }
+      return createErrorResponse(amagiError, errorMessage, rawData.code, rawData)
     }
 
     const result = createSuccessResponse(rawData, '获取成功', 200)

--- a/packages/core/src/model/fetchers/bilibili/types.ts
+++ b/packages/core/src/model/fetchers/bilibili/types.ts
@@ -213,6 +213,9 @@ export interface IBilibiliFetcher {
 
   /**
    * 获取B站动态卡片信息
+   * @deprecated v6.1.3 已废弃，B站官方已于 `2025-08-09` 删除原 `dynamic_svr` 接口。
+   * 调用将返回错误信息
+   * 计划于 v7.0.0 移除。
    */
   fetchDynamicCard: MethodOverload<BilibiliDynamicOptions, BilibiliReturnTypeMap['dynamicCard']>
 

--- a/packages/core/src/platform/bilibili/API.ts
+++ b/packages/core/src/platform/bilibili/API.ts
@@ -107,7 +107,7 @@ class BilibiliAPI {
 
   /** 获取动态卡片信息 */
   getDynamicCard (data: BilibiliMethodOptionsWithoutMethodType['DynamicParams']) {
-    return `https://api.vc.bilibili.com/dynamic_svr/v1/dynamic_svr/get_dynamic_detail?dynamic_id=${data.dynamic_id}`
+    return this.getDynamicDetail(data)
   }
 
   /** 获取用户名片信息 */

--- a/packages/core/src/platform/bilibili/API.ts
+++ b/packages/core/src/platform/bilibili/API.ts
@@ -105,7 +105,12 @@ class BilibiliAPI {
     return `https://api.bilibili.com/x/polymer/web-dynamic/v1/detail?id=${data.dynamic_id}&features=itemOpusStyle,opusBigCover,onlyfansVote,endFooterHidden,decorationCard,onlyfansAssetsV2,ugcDelete,onlyfansQaCard,editable,opusPrivateVisible,avatarAutoTheme`
   }
 
-  /** 获取动态卡片信息 */
+  /**
+   * 获取动态卡片信息
+   *
+   * @deprecated B站官方已于 `2025-08-09` 删除原 `dynamic_svr` 接口，该接口已停用。
+   * 调用将返回错误信息，请使用 {@link getDynamicDetail} 替代。
+   */
   getDynamicCard (data: BilibiliMethodOptionsWithoutMethodType['DynamicParams']) {
     return this.getDynamicDetail(data)
   }

--- a/packages/core/src/platform/bilibili/getdata.ts
+++ b/packages/core/src/platform/bilibili/getdata.ts
@@ -207,22 +207,12 @@ export const fetchBilibili = async <T extends keyof BilibiliDataOptionsMap> (
     }
 
     case 'dynamicCard': {
-      const { dynamic_id } = data
-      const hasExternalReferer = requestConfig?.headers && 'referer' in requestConfig.headers
-
-      const customHeaders = {
-        ...baseRequestConfig.headers,
-        ...(!hasExternalReferer && { Referer: undefined })
+      return {
+        code: -404,
+        message: '接口已停用：B站官方已于 `2025-08-09` 删除 dynamic_svr 接口，fetchDynamicCard 方法已废弃，调用讲返回错误信息',
+        ttl: 1,
+        data: null
       }
-
-      const dynamicDetail = await GlobalGetData(data.methodType, {
-        ...baseRequestConfig,
-        headers: customHeaders,
-        url: bilibiliApiUrls.getDynamicCard({ dynamic_id })
-      })
-      if (dynamicDetail.code !== 0) return dynamicDetail
-
-      return await buildDynamicCardCompat(dynamicDetail, data.methodType, baseRequestConfig)
     }
 
     case 'userCard': {
@@ -465,122 +455,7 @@ export const fetchBilibili = async <T extends keyof BilibiliDataOptionsMap> (
   }
 }
 
-const oldDynamicTypeMap: Record<string, number> = {
-  DYNAMIC_TYPE_FORWARD: 1,
-  DYNAMIC_TYPE_AV: 8,
-  DYNAMIC_TYPE_DRAW: 2,
-  DYNAMIC_TYPE_WORD: 4,
-  DYNAMIC_TYPE_ARTICLE: 64,
-  DYNAMIC_TYPE_LIVE_RCMD: 4308
-}
 
-const getDynamicRid = (item: Record<string, any>) => {
-  if (item.type === 'DYNAMIC_TYPE_AV') {
-    return item.modules?.module_dynamic?.major?.archive?.aid ?? item.basic?.rid_str ?? item.id_str ?? ''
-  }
-
-  return item.basic?.rid_str ?? item.basic?.comment_id_str ?? item.id_str ?? ''
-}
-
-const buildDynamicPictureList = (item: Record<string, any>) => {
-  const pics = item.modules?.module_dynamic?.major?.opus?.pics
-  if (!Array.isArray(pics)) return []
-
-  return pics
-    .map((pic: Record<string, any>) => ({
-      img_src: pic.url,
-      img_width: pic.width,
-      img_height: pic.height,
-      img_size: pic.size
-    }))
-    .filter((pic: Record<string, any>) => typeof pic.img_src === 'string' && pic.img_src.length > 0)
-}
-
-const buildDynamicLiveInfo = (item: Record<string, any>) => {
-  const liveContent = item.modules?.module_dynamic?.major?.live_rcmd?.content
-  if (typeof liveContent !== 'string' || liveContent.length === 0) return null
-
-  try {
-    return JSON.parse(liveContent)
-  } catch {
-    return null
-  }
-}
-
-const fetchDynamicArchiveInfo = async (
-  item: Record<string, any>,
-  methodType: string,
-  baseRequestConfig: AxiosRequestConfig
-) => {
-  const archive = item.modules?.module_dynamic?.major?.archive
-  const bvid = archive?.bvid
-  if (typeof bvid !== 'string' || bvid.length === 0) return null
-
-  const videoInfo = await GlobalGetData(methodType, {
-    ...baseRequestConfig,
-    url: bilibiliApiUrls.getVideoInfo({ bvid })
-  })
-
-  if (videoInfo.code !== 0) return null
-  return videoInfo.data
-}
-
-const buildDynamicCardCompat = async (
-  dynamicDetail: Record<string, any>,
-  methodType: string,
-  baseRequestConfig: AxiosRequestConfig
-) => {
-  const item = dynamicDetail.data?.item ?? {}
-  const author = item.modules?.module_author ?? {}
-  const archiveInfo = await fetchDynamicArchiveInfo(item, methodType, baseRequestConfig)
-  const archive = item.modules?.module_dynamic?.major?.archive ?? {}
-  const liveInfo = buildDynamicLiveInfo(item)
-  const rid = getDynamicRid(item)
-  const bvid = archiveInfo?.bvid ?? archive.bvid ?? ''
-  const aid = archiveInfo?.aid ?? Number(archive.aid) ?? 0
-  const oldType = oldDynamicTypeMap[item.type as string] ?? 0
-  const cardData = {
-    item: {
-      pictures: buildDynamicPictureList(item)
-    },
-    live_play_info: liveInfo?.live_play_info,
-    aid,
-    cid: archiveInfo?.cid ?? 0,
-    stat: {
-      view: archiveInfo?.stat?.view ?? Number(archive.stat?.play) ?? 0,
-      coin: archiveInfo?.stat?.coin ?? 0
-    }
-  }
-
-  return {
-    code: 0,
-    message: dynamicDetail.message ?? '0',
-    ttl: dynamicDetail.ttl ?? 1,
-    data: {
-      card: {
-        card: JSON.stringify(cardData),
-        desc: {
-          bvid,
-          dynamic_id: Number(item.id_str ?? 0),
-          dynamic_id_str: item.id_str ?? '',
-          like: item.modules?.module_stat?.like?.count ?? 0,
-          orig_dy_id: Number(item.orig?.id_str ?? 0),
-          orig_dy_id_str: item.orig?.id_str ?? '',
-          orig_type: oldDynamicTypeMap[item.orig?.type as string] ?? 0,
-          rid: Number(rid) || Number(item.id_str ?? 0) || 0,
-          rid_str: String(rid),
-          repost: item.modules?.module_stat?.forward?.count ?? 0,
-          timestamp: author.pub_ts ?? 0,
-          type: oldType,
-          uid: author.mid ?? 0,
-          view: cardData.stat.view
-        },
-        display: {},
-        extend_json: ''
-      }
-    }
-  }
-}
 
 /**
  * 获取数据

--- a/packages/core/src/platform/bilibili/getdata.ts
+++ b/packages/core/src/platform/bilibili/getdata.ts
@@ -215,12 +215,14 @@ export const fetchBilibili = async <T extends keyof BilibiliDataOptionsMap> (
         ...(!hasExternalReferer && { Referer: undefined })
       }
 
-      const result = await GlobalGetData(data.methodType, {
+      const dynamicDetail = await GlobalGetData(data.methodType, {
         ...baseRequestConfig,
         headers: customHeaders,
         url: bilibiliApiUrls.getDynamicCard({ dynamic_id })
       })
-      return result
+      if (dynamicDetail.code !== 0) return dynamicDetail
+
+      return await buildDynamicCardCompat(dynamicDetail, data.methodType, baseRequestConfig)
     }
 
     case 'userCard': {
@@ -460,6 +462,123 @@ export const fetchBilibili = async <T extends keyof BilibiliDataOptionsMap> (
     default:
       logger.warn(`未知的B站数据接口：「${logger.red((data as any).methodType)}」`)
       return null
+  }
+}
+
+const oldDynamicTypeMap: Record<string, number> = {
+  DYNAMIC_TYPE_FORWARD: 1,
+  DYNAMIC_TYPE_AV: 8,
+  DYNAMIC_TYPE_DRAW: 2,
+  DYNAMIC_TYPE_WORD: 4,
+  DYNAMIC_TYPE_ARTICLE: 64,
+  DYNAMIC_TYPE_LIVE_RCMD: 4308
+}
+
+const getDynamicRid = (item: Record<string, any>) => {
+  if (item.type === 'DYNAMIC_TYPE_AV') {
+    return item.modules?.module_dynamic?.major?.archive?.aid ?? item.basic?.rid_str ?? item.id_str ?? ''
+  }
+
+  return item.basic?.rid_str ?? item.basic?.comment_id_str ?? item.id_str ?? ''
+}
+
+const buildDynamicPictureList = (item: Record<string, any>) => {
+  const pics = item.modules?.module_dynamic?.major?.opus?.pics
+  if (!Array.isArray(pics)) return []
+
+  return pics
+    .map((pic: Record<string, any>) => ({
+      img_src: pic.url,
+      img_width: pic.width,
+      img_height: pic.height,
+      img_size: pic.size
+    }))
+    .filter((pic: Record<string, any>) => typeof pic.img_src === 'string' && pic.img_src.length > 0)
+}
+
+const buildDynamicLiveInfo = (item: Record<string, any>) => {
+  const liveContent = item.modules?.module_dynamic?.major?.live_rcmd?.content
+  if (typeof liveContent !== 'string' || liveContent.length === 0) return null
+
+  try {
+    return JSON.parse(liveContent)
+  } catch {
+    return null
+  }
+}
+
+const fetchDynamicArchiveInfo = async (
+  item: Record<string, any>,
+  methodType: string,
+  baseRequestConfig: AxiosRequestConfig
+) => {
+  const archive = item.modules?.module_dynamic?.major?.archive
+  const bvid = archive?.bvid
+  if (typeof bvid !== 'string' || bvid.length === 0) return null
+
+  const videoInfo = await GlobalGetData(methodType, {
+    ...baseRequestConfig,
+    url: bilibiliApiUrls.getVideoInfo({ bvid })
+  })
+
+  if (videoInfo.code !== 0) return null
+  return videoInfo.data
+}
+
+const buildDynamicCardCompat = async (
+  dynamicDetail: Record<string, any>,
+  methodType: string,
+  baseRequestConfig: AxiosRequestConfig
+) => {
+  const item = dynamicDetail.data?.item ?? {}
+  const author = item.modules?.module_author ?? {}
+  const archiveInfo = await fetchDynamicArchiveInfo(item, methodType, baseRequestConfig)
+  const archive = item.modules?.module_dynamic?.major?.archive ?? {}
+  const liveInfo = buildDynamicLiveInfo(item)
+  const rid = getDynamicRid(item)
+  const bvid = archiveInfo?.bvid ?? archive.bvid ?? ''
+  const aid = archiveInfo?.aid ?? Number(archive.aid) ?? 0
+  const oldType = oldDynamicTypeMap[item.type as string] ?? 0
+  const cardData = {
+    item: {
+      pictures: buildDynamicPictureList(item)
+    },
+    live_play_info: liveInfo?.live_play_info,
+    aid,
+    cid: archiveInfo?.cid ?? 0,
+    stat: {
+      view: archiveInfo?.stat?.view ?? Number(archive.stat?.play) ?? 0,
+      coin: archiveInfo?.stat?.coin ?? 0
+    }
+  }
+
+  return {
+    code: 0,
+    message: dynamicDetail.message ?? '0',
+    ttl: dynamicDetail.ttl ?? 1,
+    data: {
+      card: {
+        card: JSON.stringify(cardData),
+        desc: {
+          bvid,
+          dynamic_id: Number(item.id_str ?? 0),
+          dynamic_id_str: item.id_str ?? '',
+          like: item.modules?.module_stat?.like?.count ?? 0,
+          orig_dy_id: Number(item.orig?.id_str ?? 0),
+          orig_dy_id_str: item.orig?.id_str ?? '',
+          orig_type: oldDynamicTypeMap[item.orig?.type as string] ?? 0,
+          rid: Number(rid) || Number(item.id_str ?? 0) || 0,
+          rid_str: String(rid),
+          repost: item.modules?.module_stat?.forward?.count ?? 0,
+          timestamp: author.pub_ts ?? 0,
+          type: oldType,
+          uid: author.mid ?? 0,
+          view: cardData.stat.view
+        },
+        display: {},
+        extend_json: ''
+      }
+    }
   }
 }
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -7,6 +7,7 @@
  */
 
 import { amagiEvents, emitLogMark } from 'amagi/model/events'
+import type { AmagiEventMap, AmagiEventType } from 'amagi/model/events'
 import { createBoundBilibiliFetcher, createBoundDouyinFetcher, createBoundKuaishouFetcher, createBoundXiaohongshuFetcher } from 'amagi/model/fetchers'
 import { bilibiliUtils, createBilibiliRoutes, createDouyinRoutes, createKuaishouRoutes, douyinUtils, kuaishouUtils } from 'amagi/platform'
 import { createBoundBilibiliApi } from 'amagi/platform/bilibili/BilibiliApi'
@@ -144,13 +145,13 @@ export const createAmagiClient = (options?: Options) => {
      * @param event - 事件名称
      * @param listener - 事件处理函数
      */
-    on: amagiEvents.on.bind(amagiEvents),
+    on: <K extends AmagiEventType>(event: K, listener: (data: AmagiEventMap[K]) => void) => amagiEvents.on(event, listener),
     /**
      * 注册一次性事件监听器
      * @param event - 事件名称
      * @param listener - 事件处理函数 (只触发一次)
      */
-    once: amagiEvents.once.bind(amagiEvents),
+    once: <K extends AmagiEventType>(event: K, listener: (data: AmagiEventMap[K]) => void) => amagiEvents.once(event, listener),
 
     // ========== 废弃的 API (调用会抛出错误) ==========
     /** @deprecated v6 已废弃，请使用 douyin.fetcher 替代 */

--- a/packages/core/src/types/ReturnDataType/Bilibili/index.ts
+++ b/packages/core/src/types/ReturnDataType/Bilibili/index.ts
@@ -1,3 +1,7 @@
+// BiliDynamicCard，B站动态卡片API接口返回类型，已于 `2025-08-09` 被B站官方删除，现返回错误信息提示接口已停用，请使用动态详情接口替代。
+// import type { BiliDynamicCard } from './DynamicCard'
+import type { ErrorResult } from 'amagi/validation'
+
 import type { ArticleCard } from './ArticleCard'
 import type { ArticleContent } from './ArticleContent'
 import type { ArticleInfo } from './ArticleInfo'
@@ -9,7 +13,6 @@ import type { BiliCommentReply } from './BiliCommentReply'
 import type { BiliBv2AV } from './BV2AV'
 import type { ApplyCaptcha, ValidateCaptcha } from './Captcha'
 import type { ColumnInfo } from './ColumnInfo'
-import type { BiliDynamicCard } from './DynamicCard'
 import type { BiliDynamicInfoUnion } from './DynamicInfo'
 import type { BiliEmojiList } from './EmojiList'
 import type { BiliLiveRoomDef } from './LiveRoomDef'
@@ -69,7 +72,8 @@ export interface BilibiliReturnTypeMap {
   bangumiInfo: BiliBangumiVideoInfo
   bangumiStream: BiliBangumiVideoPlayurlIsLogin | BiliBangumiVideoPlayurlNoLogin
   dynamicDetail: BiliDynamicInfoUnion
-  dynamicCard: BiliDynamicCard
+  /** @deprecated 接口已停用，现返回错误信息 */
+  dynamicCard: ErrorResult
   liveRoomInfo: BiliLiveRoomDetail
   liveRoomInit: BiliLiveRoomDef
   loginStatus: any

--- a/packages/core/src/utils/deprecation.ts
+++ b/packages/core/src/utils/deprecation.ts
@@ -22,8 +22,8 @@ export interface DeprecationConfig {
   deprecatedIn: string
   /** 计划移除的版本号（可选），如 "7.0.0" */
   removedIn?: string
-  /** 替代的 API 名称或使用方式 */
-  replacement: string
+  /** 替代的 API 名称或使用方式（可选）。若接口被上游删除、无替代方案，可留空 */
+  replacement?: string
   /** 迁移指南链接或详细说明（可选） */
   migrationGuide?: string
   /** 是否抛出错误，false 则只打印警告，默认为 false */
@@ -96,9 +96,14 @@ export function checkDeprecation (apiName: string): void {
  */
 function buildDeprecationMessage (config: DeprecationConfig): string {
   const lines = [
-    `[DEPRECATED] "${config.name}" 已在 v${config.deprecatedIn} 版本废弃。`,
-    `请使用 "${config.replacement}" 替代。`
+    `[DEPRECATED] "${config.name}" 已在 v${config.deprecatedIn} 版本废弃。`
   ]
+
+  if (config.replacement) {
+    lines.push(`请使用 "${config.replacement}" 替代。`)
+  } else {
+    lines.push('此接口已被上游删除，无法继续使用，无可用替代方案。')
+  }
 
   if (config.removedIn) {
     lines.push(`此 API 将在 v${config.removedIn} 版本移除。`)
@@ -256,7 +261,6 @@ const chineseMethodDeprecations = [
   { name: '番剧基本信息数据', replacement: 'fetchBangumiInfo' },
   { name: '番剧下载信息数据', replacement: 'fetchBangumiStreamUrl' },
   { name: '动态详情数据', replacement: 'fetchDynamicDetail' },
-  { name: '动态卡片数据', replacement: 'fetchDynamicCard' },
   { name: '直播间信息', replacement: 'fetchLiveRoomInfo' },
   { name: '直播间初始化信息', replacement: 'fetchLiveRoomInitInfo' },
   { name: '登录基本信息', replacement: 'fetchLoginStatus' },
@@ -308,6 +312,24 @@ chineseMethodDeprecations.forEach(({ name, replacement }) => {
     replacement: `fetcher.${replacement}()`,
     throwError: true
   })
+})
+
+// 动态卡片数据单独注册：B站官方已删除 dynamic_svr 接口，已停用且无替代方案
+registerDeprecatedApi({
+  name: `methodType: '动态卡片数据'`,
+  deprecatedIn: '6.0.0',
+  removedIn: '7.0.0',
+  migrationGuide: 'https://amagi-docs.vercel.app/docs/changelog/6.1.3',
+  throwError: false
+})
+
+// 注册 fetchDynamicCard 为废弃（B站官方已删除 dynamic_svr 接口，已停用且无替代方案）
+registerDeprecatedApi({
+  name: 'fetchDynamicCard',
+  deprecatedIn: '6.1.3',
+  removedIn: '7.0.0',
+  migrationGuide: 'https://amagi-docs.vercel.app/docs/changelog/6.1.3',
+  throwError: false
 })
 
 export default {

--- a/packages/docs/content/docs/changelog/6.1.3.mdx
+++ b/packages/docs/content/docs/changelog/6.1.3.mdx
@@ -1,0 +1,37 @@
+---
+title: v6.1.3
+description: 2025-05-10 发布的重要变更
+---
+
+# v6.1.3 变更日志
+
+## B站
+
+### `fetchDynamicCard` 接口停用
+
+**影响接口**: `fetchDynamicCard` / `dynamicCard`
+
+B站官方已删除 `dynamic_svr/v1/dynamic_svr/get_dynamic_detail` 接口（原获取动态卡片信息接口）。
+
+自 v6.1.3 起，调用 `fetchDynamicCard` 将直接返回错误信息，不再转调其他接口做兼容：
+
+```typescript
+{
+  code: -404,
+  message: '接口已停用：B站官方已删除 dynamic_svr 接口，请使用 dynamicDetail 替代',
+  ttl: 1,
+  data: null
+}
+```
+
+**迁移方式**: 使用 `fetchDynamicDetail` 替代。
+
+```typescript
+// 之前
+const result = await fetchDynamicCard({ dynamic_id: '123456789' }, cookie)
+
+// 之后
+const result = await fetchDynamicDetail({ dynamic_id: '123456789' }, cookie)
+```
+
+该接口计划于 **v7.0.0** 从代码中彻底移除。

--- a/packages/docs/content/docs/changelog/meta.json
+++ b/packages/docs/content/docs/changelog/meta.json
@@ -1,0 +1,9 @@
+{
+  "title": "变更日志",
+  "description": "版本维度的变更记录",
+  "icon": "ScrollText",
+  "root": true,
+  "pages": [
+    "6.1.3"
+  ]
+}

--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Amagi 文档",
-  "pages": ["usage", "dev", "ai"]
+  "pages": ["usage", "dev", "ai", "changelog"]
 }


### PR DESCRIPTION
## Summary

Fix Bilibili dynamic parsing after the old dynamic card endpoint was removed.

This change makes `fetchDynamicCard` use the newer dynamic detail endpoint, then builds a legacy-compatible response shape for existing callers that still read `card.card` and `card.desc`.

## Changes

- Replace the removed `api.vc.bilibili.com/dynamic_svr/v1/dynamic_svr/get_dynamic_detail` endpoint with the newer dynamic detail API.
- Convert the new dynamic detail response back into the legacy dynamic card structure.
- Preserve commonly used fields such as author id, dynamic type, image list, archive ids, live info and basic stats.

## Testing

- Manually tested in karin-plugin-kkk with Bilibili dynamic parsing and push.
- Verified dynamic push no longer fails with “B站数据获取失败”.

## Summary by Sourcery

更新 B 站动态获取逻辑，改为使用新的动态详情 API，同时为现有使用方保留原有的响应结构。

Bug Fixes:
- 修复在旧的动态详情接口下线后，B 站动态卡片无法正常获取的问题。

Enhancements:
- 将新的动态详情字段映射回旧的动态卡片结构，保留作者、动态类型、媒体信息、直播信息及基础统计数据等关键元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Bilibili dynamic fetching to use the new dynamic detail API while preserving the legacy response shape for existing consumers.

Bug Fixes:
- Fix Bilibili dynamic card retrieval after the old dynamic detail endpoint was removed.

Enhancements:
- Map new dynamic detail fields into the legacy dynamic card structure, preserving key metadata such as author, dynamic type, media info, live info, and basic stats.

</details>